### PR TITLE
Update xmltv.py. fixes crashing if hyphen '-' in date value in epg data.

### DIFF
--- a/lib/common/xmltv.py
+++ b/lib/common/xmltv.py
@@ -197,6 +197,8 @@ class XMLTV:
                 elif elem.tag == 'date':
                     p_date = self.get_p_date(elem)
                     if p_date:
+                        if '-' in p_date:                                     
+                            p_date = p_date.replace('-', '')                         
                         _program['air_date'] = p_date
                         if len(p_date) == 4:
                             _program['formatted_date'] = p_date


### PR DESCRIPTION
Specific use case for hyphen in date data while processing epg, refers to  issue 171: https://github.com/cabernetwork/cabernet/issues/171